### PR TITLE
rename various instances of "noUniversalClosure" to "forallWrap"

### DIFF
--- a/PSOA2X/src/main/java/org/ruleml/psoa/psoa2x/common/TranslatorConfig.java
+++ b/PSOA2X/src/main/java/org/ruleml/psoa/psoa2x/common/TranslatorConfig.java
@@ -31,8 +31,8 @@ public abstract class TranslatorConfig {
 		m_transConfig.omitMemtermInNegativeAtoms = omitMemtermInNegativeAtoms;
 	}
 	
-	public void setNoUniversalClosure(boolean noUniversalClosure) {
-	    m_transConfig.noUniversalClosure = noUniversalClosure;
+	public void setForallWrap(boolean forallWrap) {
+	    m_transConfig.forallWrap = forallWrap;
 	}
 	
 	public void setReconstruct(boolean reconstruct) {

--- a/PSOACore/src/main/antlr3/org/ruleml/psoa/analyzer/SchemalessChecker.g
+++ b/PSOACore/src/main/antlr3/org/ruleml/psoa/analyzer/SchemalessChecker.g
@@ -38,7 +38,7 @@ options
     // but we are only concerned with free variables in rule. thus, we need 
     // context sensitivity.
     private boolean m_isRuleBody;
-    private boolean m_noUniversalClosure;
+    private boolean m_forallWrap;
     
     private Set<String> m_freeVars = new HashSet<String>();
     private Set<String> m_quantifiedVars = new HashSet<String>();  
@@ -50,8 +50,8 @@ options
         }
     }
     
-    public void setNoUniversalClosure(boolean noUniversalClosure) {
-        m_noUniversalClosure = noUniversalClosure;
+    public void setForallWrap(boolean forallWrap) {
+        m_forallWrap = forallWrap;
     }
 }
 
@@ -111,7 +111,7 @@ rule
 @after 
 {
     if (!m_freeVars.isEmpty()) {
-       if (m_noUniversalClosure) {
+       if (m_forallWrap) {
           throw new PSOARuntimeException("Variable(s) not explicitly quantified: ?" + String.join(", ?", m_freeVars) + " in the clause: \n" + $rule.text);
        } 
        else {
@@ -203,7 +203,7 @@ external
     ;
     
 psoa
-    :   ^(PSOA term? ^(INSTANCE term) tuple* slot*)
+    :   ^(PSOA term? ^(INSTANCE term) tuple* (slots+=slot)*)          
     ;
 
 tuple

--- a/PSOACore/src/main/java/org/ruleml/psoa/PSOAKB.java
+++ b/PSOACore/src/main/java/org/ruleml/psoa/PSOAKB.java
@@ -278,11 +278,11 @@ public class PSOAKB extends PSOAInput<PSOAKB>
 		});
 	}
 	
-	public PSOAKB schemalessChecking(boolean noUniversalClosure)
+	public PSOAKB schemalessChecking(boolean fAllWrap)
 	{
 		return transform("schemaless checking", stream -> {
 			SchemalessChecker checker = new SchemalessChecker(stream);
-			checker.setNoUniversalClosure(noUniversalClosure);
+			checker.setForallWrap(fAllWrap);
 			return checker.document();
 		});
 	}
@@ -342,7 +342,7 @@ public class PSOAKB extends PSOAInput<PSOAKB>
 	 * */
 	@Override
 	public PSOAKB FOLnormalize(RelationalTransformerConfig config) {
-		return schemalessChecking(config.noUniversalClosure).
+		return schemalessChecking(config.forallWrap).
 			   unnest().
 			   rewriteSubclass().
 			   objectify(config.differentiateObj, config.dynamicObj).

--- a/PSOACore/src/main/java/org/ruleml/psoa/transformer/TransformerConfig.java
+++ b/PSOACore/src/main/java/org/ruleml/psoa/transformer/TransformerConfig.java
@@ -3,5 +3,5 @@ package org.ruleml.psoa.transformer;
 public class TransformerConfig {
 	public boolean differentiateObj = true;
 	public boolean omitMemtermInNegativeAtoms = false;
-	public boolean noUniversalClosure = false;
+	public boolean forallWrap = false;
 }

--- a/PSOATransRun/src/main/java/org/ruleml/psoa/psoatransrun/PSOATransRunCmdLine.java
+++ b/PSOATransRun/src/main/java/org/ruleml/psoa/psoatransrun/PSOATransRunCmdLine.java
@@ -158,7 +158,7 @@ public class PSOATransRunCmdLine {
 				PrologTranslator.Config transConfig = new PrologTranslator.Config();
 				transConfig.setDynamicObj(dynamicObj);
 				transConfig.setOmitMemtermInNegativeAtoms(omitNegMem);
-				transConfig.setNoUniversalClosure(fAllWrap);
+				transConfig.setForallWrap(fAllWrap);
 				transConfig.setDifferentiateObj(differentiated);
 				transConfig.setReconstruct(reconstruct);
 				translator = new PrologTranslator(transConfig);
@@ -193,7 +193,7 @@ public class PSOATransRunCmdLine {
 				TPTPTranslator.Config transConfig = new TPTPTranslator.Config();
 				transConfig.setDynamicObj(dynamicObj);
 				transConfig.setOmitMemtermInNegativeAtoms(omitNegMem);
-				transConfig.setNoUniversalClosure(fAllWrap);
+				transConfig.setForallWrap(fAllWrap);
 				transConfig.setDifferentiateObj(differentiated);
 				transConfig.setReconstruct(reconstruct);
 				translator = new TPTPTranslator(transConfig);


### PR DESCRIPTION
this is to reflect internally the change to the more informative
--fAllWrap (-f) command-line option from --noClosUni.