### PR TITLE
add support for C-style comment blocks

### DIFF
--- a/PSOACore/src/main/antlr3/org/ruleml/psoa/parser/PSOAPS.g
+++ b/PSOACore/src/main/antlr3/org/ruleml/psoa/parser/PSOAPS.g
@@ -43,6 +43,10 @@ tokens
     package org.ruleml.psoa.parser;
 }
 
+@lexer::members {
+    private boolean printDeprecatedCommentWarning = true;
+}
+
 @members
 {
 	private List<String[]> m_imports = new ArrayList<String[]>();
@@ -439,7 +443,15 @@ curie returns [String fullIRI]
 // Comments and whitespace:
 WHITESPACE  :  (' '|'\t'|'\r'|'\n')+ { $channel = HIDDEN; } ;
 COMMENT : '%' ~('\n')* { $channel = HIDDEN; } ;
-MULTI_LINE_COMMENT :  '<!--' (options {greedy=false;} : .* ) '-->' { $channel=HIDDEN; } ;
+MULTI_LINE_COMMENT :  '<!--' (options {greedy=false;} : .* ) '-->' 
+                      { $channel=HIDDEN; }
+                      { 
+                        if (printDeprecatedCommentWarning) {
+                           System.out.println("Warning: XML-style comment blocks (delimited by '<!--'/'-->') are now deprecated and will be removed in a future release.");
+                           printDeprecatedCommentWarning = false;
+                        }                         
+                      }
+                   |  '/*' (options {greedy=false;} : .*) '*/' { $channel=HIDDEN; }	;
 
 // Keywords:
 DOCUMENT : 'Document' | 'RuleML' ;


### PR DESCRIPTION
... and print a suitable deprecation warning whenever XML-style comment blocks are used.